### PR TITLE
Fix start and finish time for an instrument

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -1,0 +1,135 @@
+# Benchmark
+
+Run `./benchmark/report.rb` in the project root directory to benchmark
+**`Clepsydra`** and **`ActiveSupport::Notifications`**.
+
+## Sample Report (Ruby 2.7)
+
+```
+Benchmarking 1M unique instruments
+
+================================================================================
+Scenario: 1 thread with 1M instruments per thread
+Warming up --------------------------------------
+           Clepsydra     1.000  i/100ms
+ActiveSupport::Notifications
+                         1.000  i/100ms
+Calculating -------------------------------------
+           Clepsydra      0.196  (± 0.0%) i/s -      1.000  in   5.113330s
+ActiveSupport::Notifications
+                          0.301  (± 4.5%) i/s -      2.000  in   6.650617s
+                   with 99.9% confidence
+
+Comparison:
+ActiveSupport::Notifications:        0.3 i/s
+           Clepsydra:        0.2 i/s - 1.54x  (± 0.07) slower
+                   with 99.9% confidence
+
+
+================================================================================
+Scenario: 10 threads with 100K instruments per thread
+Warming up --------------------------------------
+           Clepsydra     1.000  i/100ms
+ActiveSupport::Notifications
+                         1.000  i/100ms
+Calculating -------------------------------------
+           Clepsydra      0.046  (± 0.0%) i/s -      1.000  in  21.655149s
+ActiveSupport::Notifications
+                          0.014  (± 0.0%) i/s -      1.000  in  72.752881s
+                   with 99.9% confidence
+
+Comparison:
+           Clepsydra:        0.0 i/s
+ActiveSupport::Notifications:        0.0 i/s - 3.36x  (± 0.00) slower
+                   with 99.9% confidence
+
+
+================================================================================
+Scenario: 25 threads with 40K instruments per thread
+Warming up --------------------------------------
+           Clepsydra     1.000  i/100ms
+ActiveSupport::Notifications
+                         1.000  i/100ms
+Calculating -------------------------------------
+           Clepsydra      0.042  (± 0.0%) i/s -      1.000  in  24.032117s
+ActiveSupport::Notifications
+                          0.015  (± 0.0%) i/s -      1.000  in  65.460899s
+                   with 99.9% confidence
+
+Comparison:
+           Clepsydra:        0.0 i/s
+ActiveSupport::Notifications:        0.0 i/s - 2.72x  (± 0.00) slower
+                   with 99.9% confidence
+
+
+================================================================================
+Scenario: 50 threads with 20K instruments per thread
+Warming up --------------------------------------
+           Clepsydra     1.000  i/100ms
+ActiveSupport::Notifications
+                         1.000  i/100ms
+Calculating -------------------------------------
+           Clepsydra      0.040  (± 0.0%) i/s -      1.000  in  24.955935s
+ActiveSupport::Notifications
+                          0.015  (± 0.0%) i/s -      1.000  in  66.928480s
+                   with 99.9% confidence
+
+Comparison:
+           Clepsydra:        0.0 i/s
+ActiveSupport::Notifications:        0.0 i/s - 2.68x  (± 0.00) slower
+                   with 99.9% confidence
+
+
+================================================================================
+Scenario: 100 threads with 10K instruments per thread
+Warming up --------------------------------------
+           Clepsydra     1.000  i/100ms
+ActiveSupport::Notifications
+                         1.000  i/100ms
+Calculating -------------------------------------
+           Clepsydra      0.039  (± 0.0%) i/s -      1.000  in  25.563106s
+ActiveSupport::Notifications
+                          0.015  (± 0.0%) i/s -      1.000  in  68.724159s
+                   with 99.9% confidence
+
+Comparison:
+           Clepsydra:        0.0 i/s
+ActiveSupport::Notifications:        0.0 i/s - 2.69x  (± 0.00) slower
+                   with 99.9% confidence
+
+
+================================================================================
+Scenario: 200 threads with 5K instruments per thread
+Warming up --------------------------------------
+           Clepsydra     1.000  i/100ms
+ActiveSupport::Notifications
+                         1.000  i/100ms
+Calculating -------------------------------------
+           Clepsydra      0.036  (± 0.0%) i/s -      1.000  in  27.408376s
+ActiveSupport::Notifications
+                          0.013  (± 0.0%) i/s -      1.000  in  75.988921s
+                   with 99.9% confidence
+
+Comparison:
+           Clepsydra:        0.0 i/s
+ActiveSupport::Notifications:        0.0 i/s - 2.77x  (± 0.00) slower
+                   with 99.9% confidence
+
+
+================================================================================
+Scenario: 400 threads with 2.5K instruments per thread
+Warming up --------------------------------------
+           Clepsydra     1.000  i/100ms
+ActiveSupport::Notifications
+                         1.000  i/100ms
+Calculating -------------------------------------
+           Clepsydra      0.033  (± 0.0%) i/s -      1.000  in  30.255325s
+ActiveSupport::Notifications
+                          0.013  (± 0.0%) i/s -      1.000  in  74.627220s
+                   with 99.9% confidence
+
+Comparison:
+           Clepsydra:        0.0 i/s
+ActiveSupport::Notifications:        0.0 i/s - 2.47x  (± 0.00) slower
+                   with 99.9% confidence
+```

--- a/Gemfile
+++ b/Gemfile
@@ -20,10 +20,10 @@ group :test do
   gem 'timecop', '~> 0.9'
 end
 
-if RUBY_ENGINE == 'ruby' && Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7.0')
-  group :benchmark do
-    gem 'activesupport', '~> 7.0'
-  end
+group :benchmark do
+  gem 'activesupport'
+  gem 'benchmark-ips', '~> 2.9'
+  gem 'kalibera', '~> 0.1'
 end
 
 gemspec

--- a/lib/clepsydra/instrumenter.rb
+++ b/lib/clepsydra/instrumenter.rb
@@ -23,7 +23,7 @@ module Clepsydra
     end
 
     def start(event_name)
-      @notifier.start(event_name, "event_#{Clepsydra::TokenProvider.generate}")
+      @notifier.start(event_name)
     end
 
     def finish(event_name, event_id, payload)

--- a/lib/clepsydra/notifier.rb
+++ b/lib/clepsydra/notifier.rb
@@ -23,26 +23,53 @@ module Clepsydra
       subscriber
     end
 
-    def unsubscribe_all(event_name)
-      synchronize { @subscribers.delete(event_name) }
+    def unsubscribe(event_name_or_subscriber)
+      synchronize do
+        if event_name_or_subscriber.is_a?(String)
+          @subscribers.delete(event_name_or_subscriber)
+        else
+          event_name = event_name_or_subscriber.event_name
+
+          @subscribers[event_name].delete(event_name_or_subscriber)
+          @subscribers.delete(event_name) if @subscribers[event_name].length == 1
+        end
+      end
     end
 
-    def unsubscribe(subscriber)
-      synchronize { @subscribers[subscriber.event_name].delete(subscriber) }
-    end
+    def start(event_name)
+      event_id = "event_#{Clepsydra::TokenProvider.generate}"
+      start_times = current_times
 
-    def start(event_name, event_id)
-      synchronize { @subscribers[event_name].each { |s| s.start(event_id) } }
+      synchronize do
+        @subscribers[event_name].each do |subscriber|
+          subscriber.start(event_id, start_times)
+        end
+      end
 
       event_id
     end
 
     def finish(event_name, event_id, instrumenter_id, payload)
-      synchronize { @subscribers[event_name].each { |s| s.finish(event_id, instrumenter_id, payload) } }
+      finish_times = current_times
+
+      synchronize do
+        @subscribers[event_name].each do |subscriber|
+          subscriber.finish(event_id, @id, instrumenter_id, finish_times, payload)
+        end
+      end
     end
 
     def subscribed?(event_name)
       synchronize { @subscribers[event_name] }.any?
+    end
+
+    private
+
+    def current_times
+      {
+        wall_clock: Time.now,
+        monotonic: Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      }
     end
   end
 end

--- a/lib/clepsydra/subscriber.rb
+++ b/lib/clepsydra/subscriber.rb
@@ -7,36 +7,45 @@ module Clepsydra
     attr_reader :id, :event_name
 
     def initialize(event_name, monotonic, listener)
-      @id = if monotonic
-              "monotonic_subscriber_#{Clepsydra::TokenProvider.generate}"
-            else
-              "subscriber_#{Clepsydra::TokenProvider.generate}"
-            end
+      @id = "subscriber_#{Clepsydra::TokenProvider.generate}"
       @event_name = event_name
       @monotonic = monotonic
       @listener = listener
       @start_times = {}
     end
 
-    def start(event_id)
-      @start_times[event_id] = current_time
+    def start(event_id, current_times)
+      @start_times[event_id] = current_time(current_times)
     end
 
-    def finish(event_id, instrumenter_id, payload)
-      started = @start_times.delete(event_id)
+    def finish(event_id, notifier_id, instrumenter_id, current_times, payload)
+      start_time = @start_times.delete(event_id)
 
-      raise NoSuchEventError, "#{event_id} for #{@event_name} does not exist or already completed" if started.nil?
+      raise NoSuchEventError, "#{event_id} for #{@event_name} does not exist or already completed" if start_time.nil?
 
-      @listener.call(@event_name, event_id, instrumenter_id, @id, started, current_time, payload)
+      finish_time = current_time(current_times)
+      event_data = event_data(event_id, notifier_id, instrumenter_id)
+
+      @listener.call(event_data, start_time, finish_time, payload)
     end
 
     private
 
-    def current_time
+    def event_data(event_id, notifier_id, instrumenter_id)
+      {
+        'event_name' => @event_name,
+        'event_id' => event_id,
+        'notifier_id' => notifier_id,
+        'instrumenter_id' => instrumenter_id,
+        'subscriber_id' => @id
+      }
+    end
+
+    def current_time(current_times)
       if @monotonic
-        Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        current_times[:monotonic]
       else
-        Time.now
+        current_times[:wall_clock]
       end
     end
   end

--- a/spec/clepsydra_spec.rb
+++ b/spec/clepsydra_spec.rb
@@ -5,6 +5,10 @@ require 'set'
 require 'stringio'
 
 RSpec.describe Clepsydra do
+  def string_hash_to_hash(hash_string)
+    Hash[*hash_string.gsub(/[^'"\w\d]/, ' ').strip.split.map { |str| str.gsub(/['"]/, '') }]
+  end
+
   def capture_stdout
     old = $stdout
     $stdout = fake = StringIO.new
@@ -23,7 +27,7 @@ RSpec.describe Clepsydra do
 
   before do
     notifier.instance_variable_get(:@subscribers).each_key do |event_name|
-      clepsydra.unsubscribe_all(event_name)
+      clepsydra.unsubscribe(event_name)
     end
   end
 
@@ -84,12 +88,10 @@ RSpec.describe Clepsydra do
     end
 
     it 'returns wall-clock time' do
-      allow(Time).to receive(:now).and_call_original
-
+      current_time = Time.now
       subscriber = clepsydra.subscribe('foo') {}
-      subscriber.send(:current_time)
 
-      expect(Time).to have_received(:now)
+      expect(subscriber.send(:current_time, wall_clock: current_time)).to eq(current_time)
     end
   end
 
@@ -103,7 +105,7 @@ RSpec.describe Clepsydra do
       subscriber = clepsydra.monotonic_subscribe('foo-monotonic') {}
 
       expect(subscriber).to be_a(clepsydra::Subscriber)
-      expect(subscriber.id).to match(/monotonic_subscriber_[0-9a-z]{10}/)
+      expect(subscriber.id).to match(/subscriber_[0-9a-z]{10}/)
       expect(subscriber.event_name).to eq('foo-monotonic')
       expect(subscriber.instance_variable_get(:@monotonic)).to eq(true)
       expect(subscriber.instance_variable_get(:@listener)).to be_a(Proc)
@@ -116,122 +118,141 @@ RSpec.describe Clepsydra do
       expect(subscribers.count).to eq(100)
       expect(subscribers).to all(be_a(clepsydra::Subscriber))
       expect(subscribers.map(&:id).count).to eq(100)
-      expect(subscribers.map(&:id)).to all(match(/monotonic_subscriber_[0-9a-z]{10}/))
+      expect(subscribers.map(&:id)).to all(match(/subscriber_[0-9a-z]{10}/))
       expect(subscribers.map(&:event_name).uniq).to eq(['foo-monotonic'])
       expect(subscribers.map { |s| s.instance_variable_get(:@monotonic) }.uniq).to eq([true])
       expect(subscribers.map { |s| s.instance_variable_get(:@listener) }).to all(be_a(Proc))
     end
 
     it 'returns monotonic time' do
-      allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_call_original
-
+      current_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       subscriber = clepsydra.monotonic_subscribe('foo') {}
-      subscriber.send(:current_time)
 
-      expect(Process).to have_received(:clock_gettime).with(Process::CLOCK_MONOTONIC)
-    end
-  end
-
-  describe '.unsubscribe_all' do
-    before do
-      5.times { clepsydra.subscribe('foo') {} }
-      5.times { clepsydra.monotonic_subscribe('foo') {} }
-    end
-
-    context 'when subscribed' do
-      before { allow(notifier).to receive(:unsubscribe_all).with('foo').and_call_original }
-
-      it 'unsubscribes all the subscribers' do
-        expect(notifier.subscribed?('foo')).to eq(true)
-
-        clepsydra.unsubscribe_all('foo')
-
-        expect(notifier.subscribed?('foo')).to eq(false)
-        expect(notifier).to have_received(:unsubscribe_all).with('foo')
-      end
-    end
-
-    context 'when not subscribed' do
-      before { allow(notifier).to receive(:unsubscribe_all).with('foo-unsubscribed').and_call_original }
-
-      it 'does nothing' do
-        expect(notifier.subscribed?('foo-unsubscribed')).to eq(false)
-
-        clepsydra.unsubscribe_all('foo-unsubscribed')
-
-        expect(notifier.subscribed?('foo-unsubscribed')).to eq(false)
-        expect(notifier).to have_received(:unsubscribe_all).with('foo-unsubscribed')
-      end
+      expect(subscriber.send(:current_time, monotonic: current_time)).to eq(current_time)
     end
   end
 
   describe '.unsubscribe' do
-    let(:subscribers) { notifier.instance_variable_get(:@subscribers)['foo'] }
+    context 'when event' do
+      before do
+        5.times { clepsydra.subscribe('foo') {} }
+        5.times { clepsydra.monotonic_subscribe('foo') {} }
+      end
 
-    it 'unsubscribes given subscriber' do
-      first = clepsydra.subscribe('foo') {}
-      second = clepsydra.subscribe('foo') {}
-      third = clepsydra.monotonic_subscribe('foo') {}
+      context 'when subscribed' do
+        before { allow(notifier).to receive(:unsubscribe).with('foo').and_call_original }
 
-      expect(subscribers).to contain_exactly(first, second, third)
+        it 'unsubscribes all the subscribers' do
+          expect(notifier.subscribed?('foo')).to eq(true)
 
-      clepsydra.unsubscribe(second)
+          clepsydra.unsubscribe('foo')
 
-      expect(subscribers).to contain_exactly(first, third)
+          expect(notifier.subscribed?('foo')).to eq(false)
+          expect(notifier).to have_received(:unsubscribe).with('foo')
+        end
+      end
 
-      clepsydra.unsubscribe(first)
+      context 'when not subscribed' do
+        before { allow(notifier).to receive(:unsubscribe).with('foo-unsubscribed').and_call_original }
 
-      expect(subscribers).to contain_exactly(third)
+        it 'does nothing' do
+          expect(notifier.subscribed?('foo-unsubscribed')).to eq(false)
+
+          clepsydra.unsubscribe('foo-unsubscribed')
+
+          expect(notifier.subscribed?('foo-unsubscribed')).to eq(false)
+          expect(notifier).to have_received(:unsubscribe).with('foo-unsubscribed')
+        end
+      end
+    end
+
+    context 'when subscriber' do
+      let(:subscribers) { notifier.instance_variable_get(:@subscribers)['foo'] }
+
+      it 'unsubscribes given subscriber' do
+        first = clepsydra.subscribe('foo') {}
+        second = clepsydra.subscribe('foo') {}
+        third = clepsydra.monotonic_subscribe('foo') {}
+
+        expect(subscribers).to contain_exactly(first, second, third)
+
+        clepsydra.unsubscribe(second)
+
+        expect(subscribers).to contain_exactly(first, third)
+
+        clepsydra.unsubscribe(first)
+
+        expect(subscribers).to contain_exactly(third)
+      end
     end
   end
 
   describe '.instrument' do
     before { allow(instrumenter).to receive(:instrument).and_call_original }
 
-    it 'is thread safe' do
-      def _instrument(threads_count)
-        batch_size = 10_000 / threads_count
+    describe 'thread safety' do
+      it 'is thread safe' do
+        def _instrument(threads_count)
+          batch_size = 10_000 / threads_count
 
-        raise 'Invalid threads count' if (batch_size * threads_count) != 10_000
+          raise 'Invalid threads count' if (batch_size * threads_count) != 10_000
 
-        batch_size.times do |i|
-          threads = []
+          batch_size.times do |i|
+            threads = []
 
-          threads_count.times do |j|
-            threads << Thread.new { clepsydra.instrument("foo-#{(batch_size * j) + i}") { nil } }
+            threads_count.times do |j|
+              threads << Thread.new { clepsydra.instrument("foo-#{(batch_size * j) + i}") { nil } }
+            end
+
+            threads.each(&:join)
           end
-
-          threads.each(&:join)
         end
+
+        10_000.times { |i| clepsydra.subscribe("foo-#{i}") {} }
+        10_000.times { |i| clepsydra.monotonic_subscribe("foo-#{i}") {} }
+
+        10_000.times do |i|
+          expect(notifier.instance_variable_get(:@subscribers)["foo-#{i}"].count).to eq(2)
+        end
+
+        subscribers = notifier.instance_variable_get(:@subscribers).values.flatten
+
+        expect(subscribers.count).to eq(20_000)
+
+        subscribers.each { |s| allow(s).to receive(:current_time).and_call_original }
+
+        [10, 20, 40].each do |threads_count|
+          expect { _instrument(threads_count) }.not_to raise_error
+        end
+
+        expect(subscribers).to all(have_received(:current_time).exactly(6).times)
       end
+    end
 
-      10_000.times { |i| clepsydra.subscribe("foo-#{i}") {} }
-      10_000.times { |i| clepsydra.monotonic_subscribe("foo-#{i}") {} }
+    describe 'instrument time' do
+      before { Timecop.freeze }
 
-      10_000.times do |i|
-        expect(notifier.instance_variable_get(:@subscribers)["foo-#{i}"].count).to eq(2)
+      after { Timecop.return }
+
+      it 'has same start and finish time for all the subscribers of same event' do
+        100.times { clepsydra.subscribe('foo') { |*args| $stdout.puts args } }
+
+        output = capture_stdout { clepsydra.instrument('foo') {} }.split("\n")
+        start_times = output.values_at(*1.step(399, 4).to_a)
+        finish_times = output.values_at(*2.step(399, 4).to_a)
+
+        expect(start_times).to all(eq(Time.now.to_s))
+        expect(finish_times).to all(eq(Time.now.to_s))
       end
-
-      subscribers = notifier.instance_variable_get(:@subscribers).values.flatten
-
-      expect(subscribers.count).to eq(20_000)
-
-      subscribers.each { |s| allow(s).to receive(:current_time).with(no_args).and_call_original }
-
-      allow(Time).to receive(:now).and_call_original
-      allow(Process).to receive(:clock_gettime).and_call_original
-
-      [10, 20, 40].each do |threads_count|
-        expect { _instrument(threads_count) }.not_to raise_error
-      end
-
-      expect(subscribers).to all(have_received(:current_time).with(no_args).exactly(6).times)
-
-      expect(Time).to have_received(:now).with(no_args).exactly(60_000).times
-      expect(Process).to have_received(:clock_gettime).with(Process::CLOCK_MONOTONIC).exactly(60_000).times
     end
 
     context 'when subscribed' do
+      context 'when no block' do
+        it 'raises error' do
+          expect { clepsydra.instrument('foo') }.to raise_error(clepsydra::InvalidInstrumentError)
+        end
+      end
+
       context 'when block given' do
         context 'when block raises exeception' do
           it 'raises exeception' do
@@ -266,12 +287,10 @@ RSpec.describe Clepsydra do
             sum = 0
             sum_monotonic = 0
 
-            mutex = Mutex.new
-
-            clepsydra.subscribe('foo') { |*, payload| mutex.synchronize { sum += payload[:num] } }
-            clepsydra.monotonic_subscribe('foo') { |*, payload| mutex.synchronize { sum_monotonic += payload[:num] } }
-            clepsydra.subscribe('bar') { |*, payload| mutex.synchronize { sum += payload[:num] } }
-            clepsydra.monotonic_subscribe('bar') { |*, payload| mutex.synchronize { sum_monotonic += payload[:num] } }
+            clepsydra.subscribe('foo') { |*, payload| sum += payload[:num] }
+            clepsydra.subscribe('bar') { |*, payload| sum += payload[:num] }
+            clepsydra.monotonic_subscribe('foo') { |*, payload| sum_monotonic += payload[:num] }
+            clepsydra.monotonic_subscribe('bar') { |*, payload| sum_monotonic += payload[:num] }
 
             100.times do |i|
               threads = []
@@ -293,68 +312,14 @@ RSpec.describe Clepsydra do
           end
         end
       end
-
-      context 'when no block' do
-        before do
-          2.times { clepsydra.subscribe('foo') { |*args| $stdout.puts args } }
-          2.times { clepsydra.monotonic_subscribe('foo') { |*args| $stdout.puts args } }
-        end
-
-        it 'notifies all the subscribers' do
-          threads = []
-          outputs = []
-
-          mutex = Mutex.new
-
-          5.times do
-            threads << Thread.new do
-              outputs << mutex.synchronize { capture_stdout { clepsydra.instrument('foo') } }
-            end
-          end
-
-          threads.each(&:join)
-
-          expect(outputs.count).to eq(5)
-
-          events_id = Set.new
-          instrumenters_id = Set.new
-          subscribers_id = Set.new
-
-          outputs.each do |output|
-            lines = output.split("\n")
-
-            expect(lines.count).to eq(28)
-            expect(lines.values_at(0, 7, 14, 21)).to all(eq('foo'))
-            expect(lines.values_at(1, 8, 15, 22).uniq.count).to eq(1)
-            expect(lines.values_at(2, 9, 16, 23).uniq.count).to eq(1)
-            expect(lines.values_at(3, 10, 17, 24).uniq.count).to eq(4)
-
-            events_id |= lines.values_at(1, 8, 15, 22)
-            instrumenters_id |= lines.values_at(2, 9, 16, 23)
-            subscribers_id |= lines.values_at(3, 10, 17, 24)
-          end
-
-          expect(events_id.count).to eq(5)
-          expect(instrumenters_id.count).to eq(5)
-          expect(subscribers_id.count).to eq(4)
-        end
-      end
     end
 
     context 'when not subscribed' do
-      context 'when block given' do
-        it 'executes the block' do
-          payload = { name: 'foo', time: Time.now }
+      it 'executes the block' do
+        payload = { name: 'foo', time: Time.now }
 
-          expect(clepsydra.instrument('foo', payload) { |*args| args }).to eq([payload])
-          expect(instrumenter).not_to have_received(:instrument)
-        end
-      end
-
-      context 'when no block' do
-        it 'does nothing' do
-          expect(clepsydra.instrument('foo')).to eq(nil)
-        end
+        expect(clepsydra.instrument('foo', payload) { |*args| args }).to eq([payload])
+        expect(instrumenter).not_to have_received(:instrument)
       end
     end
   end
@@ -401,15 +366,17 @@ RSpec.describe Clepsydra do
           Timecop.travel(finish_time)
 
           output = capture_stdout { clepsydra.finish('foo', event_id) }.split("\n")
+          event_data = string_hash_to_hash(output[0])
 
-          expect(output.count).to eq(7)
-          expect(output[0]).to eq('foo')
-          expect(output[1]).to match(/event_[0-9a-z]{10}/)
-          expect(output[2]).to match(/instrumenter_[0-9a-z]{10}/)
-          expect(output[3]).to match(/subscriber_[0-9a-z]{10}/)
-          expect(output[4]).to eq(start_time.to_s)
-          expect(output[5]).to eq(finish_time.to_s)
-          expect(output[6]).to eq('{}')
+          expect(output.count).to eq(4)
+          expect(event_data['event_name']).to eq('foo')
+          expect(event_data['event_id']).to match(/event_[0-9a-z]{10}/)
+          expect(event_data['notifier_id']).to match(/notifier_[0-9a-z]{10}/)
+          expect(event_data['instrumenter_id']).to match(/instrumenter_[0-9a-z]{10}/)
+          expect(event_data['subscriber_id']).to match(/subscriber_[0-9a-z]{10}/)
+          expect(output[1]).to eq(start_time.to_s)
+          expect(output[2]).to eq(finish_time.to_s)
+          expect(output[3]).to eq('{}')
         end
       end
     end


### PR DESCRIPTION
Since each instrument sends the notification one by one in sync manner,
the finish time of each notification should be constant and equal to the
time when the instrumented event finished.